### PR TITLE
Add pkg_opts support for file narrowing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,56 @@
 # Files
 Contains file and directory related narrowing functions for Ido
 
-Introduces the following packages
-- `change_dir`
-- `find_files`
-- `browse`
+Introduces the following packages, and their respective default comand
+
+| PKG_NAME   | purpose                              | default command       |
+|------------|--------------------------------------|-----------------------|
+| change_dir | Change the current directory         | fd -t d -H . $HOME    |
+| find_files | Fuzzy find files                     | fd -t f -H . $HOME    |
+| browse     | Browse through directory structure   | ls -AF --group-directories-first |
+
+### Installation
+
+Install using your favorite package manager.
+
+For example using packer.nvim:
+
+```lua
+use 'ido-nvim/files'
+```
 
 ## Run
 ```vim
-:lua require("ido").pkg.run(PKG_NAME)
+:lua require("ido").pkg.run(PKG_NAME, PKG_OPTS)
 ```
 
-where `PKG_NAME` is the package you wish to run
+Where `PKG_NAME` is the package you wish to run,
+and `PKG_OPTS` is a table with configuration options.
+
+## Configuration
+
+All of the included packages support configuration by means of [pkg_opts](https://github.com/ido-nvim/core/blob/main/wiki/packages.md#package-structure).
+
+The command used for each respective package can be configured both on `pkg.run` as well as `pkg.setup`.
+For instance to overwrite the command used for `find_files`:
+
+```lua
+require("ido").pkg.setup('find_files', {
+  pkg_opts = {
+    -- overwrite the command to use RipGrep
+    command = 'rg --files --ignore --smart-case --hidden --follow --no-messages --ignore-file ~/.gitignore'
+  }
+})
+```
+
+Or to overwrite it just for a single run:
+
+```lua
+require("ido").pkg.run('find_files', {
+  -- overwrite the command to use RipGrep
+  command = 'rg --files --ignore --smart-case --hidden --follow --no-messages --ignore-file ~/.gitignore'
+})
+```
 
 ## Keybindings
 ```vim

--- a/lua/ido-pkg/browse.lua
+++ b/lua/ido-pkg/browse.lua
@@ -4,6 +4,7 @@ local main = require("ido.core.main")
 local ui = require("ido.core.ui")
 
 local pkg = ido.pkg
+local DEFAULT_COMMAND = "ls -AF --group-directories-first "
 
 --- Escape the file or directory path and resolve it
 -- @param item The file/directory path
@@ -15,13 +16,12 @@ end
 --- Get list of files and directories
 -- @param directory The directory
 -- @return output of ls with some opts
-local function list(directory)
-   return vim.fn.systemlist("ls -AF --group-directories-first "..escape(directory))
+local function list(command, directory)
+   return vim.fn.systemlist(command..escape(directory))
 end
 
 -- File browser
-local function browse()
-
+local function browse(pkg_opts)
    -- Do not exit on accept, instead do this
    advice.set("exit_on_accept_selected", "overwrite", function ()
       local vars = ido.sandbox.vars
@@ -43,7 +43,7 @@ local function browse()
 
          -- Change to the directory
          opts.prompt = opts.prompt..selected
-         vars.items = list(opts.prompt:sub(9, -1))
+         vars.items = list(pkg_opts.command, opts.prompt:sub(9, -1))
 
          -- Clear the query
          vars.before_cursor = ""
@@ -77,7 +77,7 @@ local function browse()
          end
 
          opts.prompt = opts.prompt:gsub("[^/]*/$", "")
-         vars.items = list(opts.prompt:sub(9, -1))
+         vars.items = list(pkg_opts.command, opts.prompt:sub(9, -1))
          main.async(main.get_results)
       end
 
@@ -93,7 +93,7 @@ local function browse()
 
          -- Change to the directory
          opts.prompt = opts.prompt..vars.before_cursor..vars.after_cursor
-         vars.items = list(opts.prompt:sub(9, -1))
+         vars.items = list(pkg_opts.command, opts.prompt:sub(9, -1))
 
          -- Clear the query
          vars.before_cursor = ""
@@ -120,7 +120,7 @@ local function browse()
    directory = directory:gsub("/$", "").."/"
 
    pkg.start({
-      items = list(directory),
+      items = list(pkg_opts.command, directory),
       prompt = "Browse: "..directory,
    })
 
@@ -130,7 +130,9 @@ end
 -- Setup the package
 pkg.new("browse", {
    main = browse,
-
+   pkg_opts = {
+      command = DEFAULT_COMMAND
+   },
    disable = {
       "prompt"
    }

--- a/lua/ido-pkg/cd.lua
+++ b/lua/ido-pkg/cd.lua
@@ -1,9 +1,10 @@
 local pkg = require("ido").pkg
+local DEFAULT_COMMAND  = "fd -t d -H . $HOME"
 
 -- Change the current directory
-local function change_dir()
+local function change_dir(pkg_opts)
    local dir = pkg.start({
-      items = vim.fn.systemlist("fd -t d -H . $HOME"),
+      items = vim.fn.systemlist(pkg_opts.command),
       prompt = "Dirs: ",
    })
 

--- a/lua/ido-pkg/files.lua
+++ b/lua/ido-pkg/files.lua
@@ -1,9 +1,10 @@
 local pkg = require("ido").pkg
+local DEFAULT_COMMAND = "fd -t f -H . $HOME"
 
 -- Fuzzy find files
-local function find_files()
+local function find_files(pkg_opts)
    local file = pkg.start({
-      items = vim.fn.systemlist("fd -t f -H . $HOME"),
+      items = vim.fn.systemlist(pkg_opts.command),
       prompt = "Files: ",
    })
 
@@ -17,4 +18,7 @@ end
 -- Setup the package
 pkg.new("find_files", {
    main = find_files,
+   pkg_opts = {
+      command = DEFAULT_COMMAND
+   }
 })


### PR DESCRIPTION
Fixes https://github.com/ido-nvim/files/issues/3

With https://github.com/ido-nvim/core/pull/21 being merged, we can now solve the issue of the incompatible commands by making them configurable using `pkg_opts`

This PR does just that, it sticks with the current default commands but makes  it easy to overwrite the command for each respective source/PKG.

screenshot of updated readme:

<img width="908" alt="image" src="https://user-images.githubusercontent.com/1220084/109951793-6ab89e00-7cde-11eb-8290-5bd98f61e3c6.png">
